### PR TITLE
Refactor choosePuzzle method on Puzzle class to store puzzle value in newPuzzle.

### DIFF
--- a/src/Puzzle.js
+++ b/src/Puzzle.js
@@ -1,8 +1,10 @@
+import { throws } from "assert";
+
 class Puzzle {
   constructor(puzzles) {
     this.fullBank = puzzles;
     this.chosenBank = [];
-    this.newPuzzle = this.choosePuzzle();
+    this.newPuzzle = {};
   }
 
   choosePuzzleBank() {
@@ -11,11 +13,17 @@ class Puzzle {
     let chosenOption = options[index];
     this.chosenBank = this.fullBank[chosenOption].puzzle_bank;
   }
-
-  choosePuzzle() {
+  
+  setPuzzle() {
     let index = Math.floor(Math.random() * 24);
-    return this.chosenBank[index];
+    this.newPuzzle = this.chosenBank[index];
+    return this.newPuzzle;
   }
+
+  createPuzzleArray() {
+    return this.newPuzzle
+  }
+
 }
 
 export default Puzzle;

--- a/src/Puzzle.js
+++ b/src/Puzzle.js
@@ -13,16 +13,16 @@ class Puzzle {
     let chosenOption = options[index];
     this.chosenBank = this.fullBank[chosenOption].puzzle_bank;
   }
-  
+
   setPuzzle() {
     let index = Math.floor(Math.random() * 24);
     this.newPuzzle = this.chosenBank[index];
     return this.newPuzzle;
   }
 
-  createPuzzleArray() {
-    return this.newPuzzle
-  }
+  // createPuzzleArray() {
+  //   return this.newPuzzle
+  // }
 
 }
 

--- a/test/Puzzle-test.js
+++ b/test/Puzzle-test.js
@@ -11,7 +11,7 @@ describe('Puzzle', () => {
   });
 
   it('should store all the puzzles from the puzzle bank', () => {
-    expect(puzzle.fullBank).to.eql(data.puzzles);
+    expect(puzzle.fullBank).to.equal(data.puzzles);
   });
 
   it('should be able to randomly pick a bank of puzzles', () => {
@@ -19,8 +19,17 @@ describe('Puzzle', () => {
     expect(puzzle.chosenBank.length).to.equal(24);
   });
 
-  it('should be able to return a random puzzle from the chosen bank', () => {
+  it.only('should be able to return a random puzzle from the chosen bank', () => {
     puzzle.choosePuzzleBank();
-    expect([puzzle.choosePuzzle()].length).to.equal(1);
+    puzzle.setPuzzle();
+    expect(puzzle.newPuzzle).to.be.an('object');
   });
+
+  it.only('should return the puzzle answer as an array', () => {
+    puzzle.choosePuzzleBank();
+    puzzle.setPuzzle();
+    console.log(puzzle.createPuzzleArray());
+    expect(puzzle.newPuzzle).to.be.an('object');
+  }); 
+
 });

--- a/test/Puzzle-test.js
+++ b/test/Puzzle-test.js
@@ -28,7 +28,7 @@ describe('Puzzle', () => {
   it.only('should return the puzzle answer as an array', () => {
     puzzle.choosePuzzleBank();
     puzzle.setPuzzle();
-    console.log(puzzle.createPuzzleArray());
+    // console.log(puzzle.createPuzzleArray());
     expect(puzzle.newPuzzle).to.be.an('object');
   }); 
 

--- a/test/Wheel-test.js
+++ b/test/Wheel-test.js
@@ -22,4 +22,5 @@ describe('See if the tests are running', function () {
     expect(wheel.wheelVals).to.include(wheel.currentVal);
   });
   
+  
 });

--- a/test/Wheel-test.js
+++ b/test/Wheel-test.js
@@ -18,7 +18,7 @@ describe('See if the tests are running', function () {
   });
   
 
-  it.only('should be able to hold the Wheel of Fortune values', () => {
+  it('should be able to hold the Wheel of Fortune values', () => {
     expect(wheel.wheelVals).to.include(wheel.currentVal);
   });
   


### PR DESCRIPTION
Refactor choosePuzzle method on Puzzle class to store puzzle value in newPuzzle. Changed name to setPuzzle to avoid confusion with choosePuzzleBank.

Breaks startRound() method on Round.  Must refactor to reflect changes.